### PR TITLE
[FEAT] Adding systemd-container to provide machinectl

### DIFF
--- a/src/base/.devcontainer/Containerfile
+++ b/src/base/.devcontainer/Containerfile
@@ -23,6 +23,7 @@ dnf5 install -y \
     openssl \
     python3 \
     rpm-ostree \
+    systemd-container \
     selinux-policy-targeted \
     sbsigntools \
     shfmt \


### PR DESCRIPTION
Machinectl is needed to build iso

Closes #120 